### PR TITLE
PropertType: Specify type for custom discriminant values

### DIFF
--- a/src/one/property/mod.rs
+++ b/src/one/property/mod.rs
@@ -23,6 +23,7 @@ mod references;
 pub(crate) mod simple;
 pub(crate) mod time;
 
+#[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[allow(dead_code)]
 #[allow(clippy::enum_clike_unportable_variant)]


### PR DESCRIPTION
We use custom discriminant values for enum variants for "PropertType" without specifying the type. This causes it to default to "isize" which on 64bit platforms is big enough to hold the 32bit constants, but causes overflow when isize is 32bit.

This issue was uncovered due to build failures on arm for Gentoo Linux as a dependency of ClamAV.

Bug: https://bugs.gentoo.org/927214