### PR TITLE
fix: allow enum `PropertyType` to overflow

### DIFF
--- a/src/one/property/mod.rs
+++ b/src/one/property/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod time;
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[allow(dead_code)]
 #[allow(clippy::enum_clike_unportable_variant)]
+#[allow(overflowing_literals)]
 pub(crate) enum PropertyType {
     ActionItemSchemaVersion = 0x0C003473,
     ActionItemStatus = 0x10003470,


### PR DESCRIPTION
A couple of the values (`InkAntialised`, `InkFitToCurve`) for the `ProperyType` enum are assigned negative values when building for the 32-bit x86 architecture. Since the `PropertyType` enum doesn't appear to be used in any mathematical operations it should be safe to allow it to overflow.