### PR TITLE
fix parser missing paragraph styles

### DIFF
--- a/crates/parser/src/one/property_set/rich_text_node.rs
+++ b/crates/parser/src/one/property_set/rich_text_node.rs
@@ -22,7 +22,7 @@ pub(crate) struct Data {
     pub(crate) text_run_formatting: Vec<ExGuid>,
     pub(crate) text_run_indices: Vec<u32>,
     pub(crate) text_run_data_object: Vec<ExGuid>,
-    pub(crate) paragraph_style: ExGuid,
+    pub(crate) paragraph_style: Option<ExGuid>,
     pub(crate) paragraph_space_before: f32,
     pub(crate) paragraph_space_after: f32,
     pub(crate) paragraph_line_spacing_exact: Option<f32>,
@@ -54,10 +54,7 @@ pub(crate) fn parse(object: &Object) -> Result<Data> {
         simple::parse_vec_u32(PropertyType::TextRunIndex, object)?.unwrap_or_default();
     let text_run_data_object =
         ObjectReference::parse_vec(PropertyType::TextRunDataObject, object)?.unwrap_or_default();
-    let paragraph_style = ObjectReference::parse(PropertyType::ParagraphStyle, object)?
-        .ok_or_else(|| {
-            ErrorKind::MalformedOneNoteFileData("rich text has no paragraph style".into())
-        })?;
+    let paragraph_style = ObjectReference::parse(PropertyType::ParagraphStyle, object)?;
     let paragraph_space_before =
         simple::parse_f32(PropertyType::ParagraphSpaceBefore, object)?.unwrap_or_default();
     let paragraph_space_after =

--- a/crates/parser/src/onenote/rich_text.rs
+++ b/crates/parser/src/onenote/rich_text.rs
@@ -207,7 +207,7 @@ impl EmbeddedInkSpace {
 ///
 /// [\[MS-ONE\] 2.2.43]: https://docs.microsoft.com/en-us/openspecs/office_file_formats/ms-one/38eb9b74-cfaf-4df7-b061-a83968c7ff5b
 /// [\[MS-ONE\] 2.2.44]: https://docs.microsoft.com/en-us/openspecs/office_file_formats/ms-one/f0baabae-f42a-42e0-8cb2-869d420e865f
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ParagraphStyling {
     pub(crate) charset: Option<Charset>,
     pub(crate) bold: bool,
@@ -413,11 +413,16 @@ pub(crate) fn parse_rich_text(
     let data = rich_text_node::parse(object)?;
 
     // Parse the base paragraph style
-    let paragraph_style_object = space
-        .get_object(data.paragraph_style)
-        .ok_or_else(|| ErrorKind::MalformedOneNoteData("paragraph styling is missing".into()))?;
-    let paragraph_style_data = paragraph_style_object::parse(paragraph_style_object, ctx)?;
-    let paragraph_style = parse_style(paragraph_style_data);
+    let paragraph_style = if let Some(paragraph_style_id) = data.paragraph_style {
+        let paragraph_style_object = space
+            .get_object(paragraph_style_id)
+            .ok_or_else(|| ErrorKind::MalformedOneNoteData("paragraph styling is missing".into()))?;
+        let paragraph_style_data = paragraph_style_object::parse(paragraph_style_object, ctx)?;
+        parse_style(paragraph_style_data)
+    } else {
+        warn!(ctx, "rich text has no paragraph style; using defaults");
+        ParagraphStyling::default()
+    };
 
     // Parse the styles text runs (part 1)
     let style_objects: Vec<_> = data


### PR DESCRIPTION
Hello, thanks for maintaining the library.
While testing the library with my own exported onenote files, I got the error that the paragraph style is missing. Inside the docs it is mentioned that they must exist, but in reality it didn't (tested on OneNote Windows App with a .one and a .onepkg file)