### PR TITLE
fix(parser): preserve unavailable attachment payloads

### DIFF
--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -201,6 +201,7 @@ pub mod contents {
         EmbeddedInkContainer, EmbeddedInkSpace, EmbeddedObject, ParagraphStyling, RichText,
     };
     pub use crate::onenote::table::{Table, TableCell, TableRow};
+    pub use crate::onestore::shared::file_blob::FileDataStatus;
 }
 
 /// Collection of properties used by the OneNote file format.

--- a/crates/parser/src/onenote/content.rs
+++ b/crates/parser/src/onenote/content.rs
@@ -95,9 +95,9 @@ pub(crate) fn parse_content(
     })?;
 
     let content = match id {
-        PropertySetId::ImageNode => Content::Image(parse_image(content_id, space)?),
+        PropertySetId::ImageNode => Content::Image(parse_image(content_id, space, ctx)?),
         PropertySetId::EmbeddedFileNode => {
-            Content::EmbeddedFile(parse_embedded_file(content_id, space)?)
+            Content::EmbeddedFile(parse_embedded_file(content_id, space, ctx)?)
         }
         PropertySetId::RichTextNode => Content::RichText(parse_rich_text(content_id, space, ctx)?),
         PropertySetId::TableNode => Content::Table(parse_table(content_id, space, ctx)?),

--- a/crates/parser/src/onenote/embedded_file.rs
+++ b/crates/parser/src/onenote/embedded_file.rs
@@ -2,9 +2,10 @@ use crate::errors::{ErrorKind, Result};
 use crate::fsshttpb::data::exguid::ExGuid;
 use crate::one::property::file_type::FileType;
 use crate::one::property_set::{embedded_file_container, embedded_file_node};
+use crate::onenote::ParserContext;
 use crate::onenote::note_tag::{NoteTag, parse_note_tags};
 use crate::onestore::ObjectSpace;
-use crate::onestore::shared::file_blob::FileBlob;
+use crate::onestore::shared::file_blob::{FileBlob, FileDataStatus};
 
 /// An embedded file.
 ///
@@ -64,6 +65,10 @@ impl EmbeddedFile {
     /// the reader. With a memory-mapped backing the read is zero-copy; with
     /// a lazy backing each call to `read` triggers a fetch sized by the
     /// caller's buffer.
+    ///
+    /// For compatibility, unavailable data produces an empty reader. Call
+    /// [`data_status`](Self::data_status) first to distinguish it from a
+    /// valid zero-byte file.
     pub fn read(&self) -> Box<dyn std::io::Read> {
         self.data.read()
     }
@@ -71,6 +76,14 @@ impl EmbeddedFile {
     /// The size of the embedded file in bytes.
     pub fn size(&self) -> u64 {
         self.data.size()
+    }
+
+    /// Availability of the embedded file's binary data.
+    ///
+    /// Consumers should render a broken-content indicator when this is not
+    /// [`FileDataStatus::Available`].
+    pub fn data_status(&self) -> FileDataStatus {
+        self.data.status()
     }
 
     /// The max width of the embedded file's icon in half-inch increments.
@@ -118,6 +131,7 @@ impl EmbeddedFile {
 pub(crate) fn parse_embedded_file(
     file_id: ExGuid,
     space: &(impl ObjectSpace + ?Sized),
+    ctx: &mut ParserContext,
 ) -> Result<EmbeddedFile> {
     let node_object = space
         .get_object(file_id)
@@ -129,7 +143,7 @@ pub(crate) fn parse_embedded_file(
         Ok(EmbeddedFile {
             filename,
             file_type: node.file_type,
-            data: FileBlob::default(),
+            data: FileBlob::missing(),
             layout_max_width: node.layout_max_width,
             layout_max_height: node.layout_max_height,
             offset_horizontal: node.offset_from_parent_horiz,
@@ -141,12 +155,24 @@ pub(crate) fn parse_embedded_file(
     // Check if we have the required fields to parse a valid embedded file
     let embedded_filename = match node.embedded_file_name {
         Some(name) => name,
-        None => return create_fallback(String::new()),
+        None => {
+            warn!(
+                ctx,
+                "embedded file has no filename; preserving it as unavailable"
+            );
+            return create_fallback(String::new());
+        }
     };
 
     let container_object_id = match node.embedded_file_container {
         Some(id) => id,
-        None => return create_fallback(embedded_filename),
+        None => {
+            warn!(
+                ctx,
+                "embedded file has no data container; preserving file metadata"
+            );
+            return create_fallback(embedded_filename);
+        }
     };
 
     let container_object = space.get_object(container_object_id).ok_or_else(|| {
@@ -164,6 +190,13 @@ pub(crate) fn parse_embedded_file(
         offset_vertical: node.offset_from_parent_vert,
         note_tags: parse_note_tags(&node.note_tags, space)?,
     };
+
+    if file.data_status() == FileDataStatus::Invalid {
+        warn!(
+            ctx,
+            "embedded file payload is marked invalid; preserving file metadata"
+        );
+    }
 
     Ok(file)
 }

--- a/crates/parser/src/onenote/image.rs
+++ b/crates/parser/src/onenote/image.rs
@@ -2,10 +2,11 @@ use crate::errors::{ErrorKind, Result};
 use crate::fsshttpb::data::exguid::ExGuid;
 use crate::one::property::layout_alignment::LayoutAlignment;
 use crate::one::property_set::{image_node, picture_container};
+use crate::onenote::ParserContext;
 use crate::onenote::iframe::{IFrame, parse_iframe};
 use crate::onenote::note_tag::{NoteTag, parse_note_tags};
 use crate::onestore::ObjectSpace;
-use crate::onestore::shared::file_blob::FileBlob;
+use crate::onestore::shared::file_blob::{FileBlob, FileDataStatus};
 
 /// An embedded image.
 ///
@@ -52,7 +53,9 @@ impl Image {
     /// A [`Read`] over the image's binary data.
     ///
     /// Bytes are pulled lazily from the underlying [`crate::fs::FileSource`].
-    /// Returns `None` if the image data hasn't been uploaded yet.
+    /// Returns `None` if the image data hasn't been uploaded yet. Call
+    /// [`data_status`](Self::data_status) before reading to distinguish
+    /// invalid data from a valid zero-byte payload.
     pub fn read(&self) -> Option<Box<dyn std::io::Read>> {
         self.data.as_ref().map(|blob| blob.read())
     }
@@ -60,6 +63,17 @@ impl Image {
     /// The size of the image in bytes, or `None` if not yet uploaded.
     pub fn size(&self) -> Option<u64> {
         self.data.as_ref().map(|blob| blob.size())
+    }
+
+    /// Availability of the image's binary data.
+    ///
+    /// Consumers should render a broken-content indicator for
+    /// [`FileDataStatus::Invalid`] instead of treating it as a valid
+    /// zero-byte image.
+    pub fn data_status(&self) -> FileDataStatus {
+        self.data
+            .as_ref()
+            .map_or(FileDataStatus::Missing, FileBlob::status)
     }
 
     /// The image's file extension.
@@ -203,7 +217,11 @@ impl Image {
     }
 }
 
-pub(crate) fn parse_image(image_id: ExGuid, space: &(impl ObjectSpace + ?Sized)) -> Result<Image> {
+pub(crate) fn parse_image(
+    image_id: ExGuid,
+    space: &(impl ObjectSpace + ?Sized),
+    ctx: &mut ParserContext,
+) -> Result<Image> {
     let node_object = space
         .get_object(image_id)
         .ok_or_else(|| ErrorKind::MalformedOneNoteData("image is missing".into()))?;
@@ -253,6 +271,13 @@ pub(crate) fn parse_image(image_id: ExGuid, space: &(impl ObjectSpace + ?Sized))
         note_tags: parse_note_tags(&node.note_tags, space)?,
         embeds: embed,
     };
+
+    if image.data_status() == FileDataStatus::Invalid {
+        warn!(
+            ctx,
+            "image payload is marked invalid; preserving image metadata"
+        );
+    }
 
     Ok(image)
 }

--- a/crates/parser/src/onenote/page_content.rs
+++ b/crates/parser/src/onenote/page_content.rs
@@ -77,9 +77,9 @@ pub(crate) fn parse_page_content(
     })?;
 
     let content = match id {
-        PropertySetId::ImageNode => PageContent::Image(parse_image(content_id, space)?),
+        PropertySetId::ImageNode => PageContent::Image(parse_image(content_id, space, ctx)?),
         PropertySetId::EmbeddedFileNode => {
-            PageContent::EmbeddedFile(parse_embedded_file(content_id, space)?)
+            PageContent::EmbeddedFile(parse_embedded_file(content_id, space, ctx)?)
         }
         PropertySetId::OutlineNode => PageContent::Outline(parse_outline(content_id, space, ctx)?),
         PropertySetId::InkContainer => PageContent::Ink(parse_ink(content_id, space, ctx)?),

--- a/crates/parser/src/onestore/desktop/file_node/shared.rs
+++ b/crates/parser/src/onestore/desktop/file_node/shared.rs
@@ -238,10 +238,9 @@ pub(crate) struct AttachmentInfo {
 }
 
 impl AttachmentInfo {
-    pub(crate) fn load_data<T, F>(&self, file_blob_by_id: F) -> Result<T>
+    pub(crate) fn load_data<F>(&self, file_blob_by_id: F) -> Result<FileBlob>
     where
-        T: Default,
-        F: FnOnce(&str) -> Result<T>,
+        F: FnOnce(&str) -> Result<FileBlob>,
     {
         // See https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-onestore/da2bbc7d-0529-4bf4-a843-6f3f55c87e8f
         if self.data_ref.starts_with("<ifndf>") {
@@ -257,13 +256,14 @@ impl AttachmentInfo {
             )
             .into())
         } else if self.data_ref.starts_with("<invfdo>") {
-            // "invalid" — import as an empty file rather than failing the whole page.
+            // Preserve the invalid state rather than presenting it as a valid
+            // zero-byte payload.
             log::warn!(
-                "Attempted to load an invalid {} file. Importing an empty file.",
+                "Attempted to load an invalid {} file. Preserving it as unavailable.",
                 self.extension
             );
 
-            Ok(T::default())
+            Ok(FileBlob::invalid())
         } else {
             Err(parser_error!(
                 ResolutionFailed,

--- a/crates/parser/src/onestore/desktop/objects/file_data_store.rs
+++ b/crates/parser/src/onestore/desktop/objects/file_data_store.rs
@@ -1,6 +1,5 @@
 use crate::errors::{Error, Result};
 use crate::onestore::desktop::file_node::FileNodeData;
-use crate::onestore::desktop::file_node::shared::AttachmentInfo;
 use crate::onestore::desktop::file_node::shared::FileData;
 use crate::onestore::desktop::file_node::shared::FileDataStoreListReferenceFND;
 use crate::onestore::desktop::file_structure::FileNodeDataIterator;
@@ -50,18 +49,16 @@ impl FileDataStore {
         Ok(Self { files })
     }
 
-    pub(crate) fn find_file(&self, info: &AttachmentInfo) -> Result<FileBlob> {
-        info.load_data(|id| -> Result<FileBlob> {
-            let guid = Guid::from_str(id)?;
-            let file = self
-                .files
-                .iter()
-                .find(|file| file.id == guid)
-                .ok_or_else(|| -> Error {
-                    parser_error!(ResolutionFailed, "File not found with ID {}", id).into()
-                })?;
+    pub(crate) fn find_file(&self, id: &str) -> Result<FileBlob> {
+        let guid = Guid::from_str(id)?;
+        let file = self
+            .files
+            .iter()
+            .find(|file| file.id == guid)
+            .ok_or_else(|| -> Error {
+                parser_error!(ResolutionFailed, "File not found with ID {}", id).into()
+            })?;
 
-            Ok(file.file_data.0.clone())
-        })
+        Ok(file.file_data.0.clone())
     }
 }

--- a/crates/parser/src/onestore/desktop/objects/parse_context.rs
+++ b/crates/parser/src/onestore/desktop/objects/parse_context.rs
@@ -58,11 +58,52 @@ impl<'a> ParseContext<'a> {
     }
 
     pub(crate) fn find_file_data(&self, data_info: &AttachmentInfo) -> Result<FileBlob> {
-        let file_data_store = self.file_data_store.ok_or_else(|| -> Error {
-            parser_error!(ResolutionFailed, "file_data reference has not been loaded").into()
-        })?;
+        data_info.load_data(|id| {
+            let file_data_store = self.file_data_store.ok_or_else(|| -> Error {
+                parser_error!(ResolutionFailed, "file_data reference has not been loaded").into()
+            })?;
+            file_data_store.find_file(id)
+        })
+    }
+}
 
-        file_data_store.find_file(data_info)
+#[cfg(test)]
+mod tests {
+    use super::ParseContext;
+    use crate::onestore::desktop::file_node::shared::AttachmentInfo;
+    use crate::onestore::shared::file_blob::FileDataStatus;
+
+    #[test]
+    fn invalid_file_reference_does_not_require_a_file_data_store() {
+        let info = AttachmentInfo {
+            extension: "bin".to_owned(),
+            data_ref: "<invfdo>".to_owned(),
+        };
+
+        let blob = ParseContext::new()
+            .find_file_data(&info)
+            .expect("invalid file references should remain non-fatal");
+
+        assert_eq!(blob.status(), FileDataStatus::Invalid);
+        assert_eq!(blob.size(), 0);
+    }
+
+    #[test]
+    fn internal_file_reference_still_requires_a_file_data_store() {
+        let info = AttachmentInfo {
+            extension: "bin".to_owned(),
+            data_ref: "<ifndf>{00000000-0000-0000-0000-000000000000}".to_owned(),
+        };
+
+        let error = ParseContext::new()
+            .find_file_data(&info)
+            .expect_err("internal references require the file data store");
+
+        assert!(
+            error
+                .to_string()
+                .contains("file_data reference has not been loaded")
+        );
     }
 }
 

--- a/crates/parser/src/onestore/shared/file_blob.rs
+++ b/crates/parser/src/onestore/shared/file_blob.rs
@@ -5,6 +5,18 @@ use std::fmt::Debug;
 use std::io::{Cursor, Read};
 use std::sync::Arc;
 
+/// Availability of binary data referenced by a OneNote object.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FileDataStatus {
+    /// The binary payload is available.
+    Available,
+    /// The OneNote object does not reference a binary payload.
+    Missing,
+    /// The OneNote object explicitly marks the binary payload as invalid.
+    Invalid,
+}
+
 /// A reference to a contiguous run of bytes within a parser-managed
 /// [`FileSource`].
 ///
@@ -21,6 +33,7 @@ pub(crate) struct FileBlob {
     source: Arc<dyn FileSource>,
     offset: u64,
     size: u64,
+    status: FileDataStatus,
 }
 
 impl FileBlob {
@@ -30,6 +43,7 @@ impl FileBlob {
             source,
             offset,
             size,
+            status: FileDataStatus::Available,
         }
     }
 
@@ -41,7 +55,26 @@ impl FileBlob {
             source: Arc::new(BytesSource::new(Bytes::new())),
             offset: 0,
             size: 0,
+            status: FileDataStatus::Available,
         }
+    }
+
+    pub(crate) fn missing() -> Self {
+        Self {
+            status: FileDataStatus::Missing,
+            ..Self::empty()
+        }
+    }
+
+    pub(crate) fn invalid() -> Self {
+        Self {
+            status: FileDataStatus::Invalid,
+            ..Self::empty()
+        }
+    }
+
+    pub(crate) fn status(&self) -> FileDataStatus {
+        self.status
     }
 
     /// The size of the blob in bytes.
@@ -70,6 +103,10 @@ impl FileBlob {
 
 impl Debug for FileBlob {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.status != FileDataStatus::Available {
+            return write!(f, "FileBlob [ {:?}; 0 KiB ]", self.status);
+        }
+
         // Read up to 32 bytes from each end via `read_at` so the preview is
         // identical regardless of whether the source is in-memory or
         // lazy-backed. Errors fall back to a size-only line.
@@ -108,6 +145,7 @@ impl PartialEq for FileBlob {
         Arc::ptr_eq(&self.source, &other.source)
             && self.offset == other.offset
             && self.size == other.size
+            && self.status == other.status
     }
 }
 

--- a/crates/parser/tests/snapshots/lib__test_onenote_joplin_examples_section__new_section.snap
+++ b/crates/parser/tests/snapshots/lib__test_onenote_joplin_examples_section__new_section.snap
@@ -212,7 +212,7 @@ Section {
                                                     EmbeddedFile {
                                                         filename: "Untitled",
                                                         file_type: Unknown,
-                                                        data: FileBlob [  ... ; 0 KiB ],
+                                                        data: FileBlob [ Missing; 0 KiB ],
                                                         layout_max_width: None,
                                                         layout_max_height: None,
                                                         offset_horizontal: None,
@@ -234,7 +234,7 @@ Section {
                                                     EmbeddedFile {
                                                         filename: "Untitled",
                                                         file_type: Unknown,
-                                                        data: FileBlob [  ... ; 0 KiB ],
+                                                        data: FileBlob [ Missing; 0 KiB ],
                                                         layout_max_width: None,
                                                         layout_max_height: None,
                                                         offset_horizontal: None,
@@ -392,6 +392,25 @@ Section {
         },
     ),
     report: Report {
-        warnings: [],
+        warnings: [
+            Warning {
+                page: Some(
+                    (
+                        b8eacefb-ca13-42d8-aeca-5f277ce28041,
+                        "title",
+                    ),
+                ),
+                message: "embedded file has no data container; preserving file metadata",
+            },
+            Warning {
+                page: Some(
+                    (
+                        b8eacefb-ca13-42d8-aeca-5f277ce28041,
+                        "title",
+                    ),
+                ),
+                message: "embedded file has no data container; preserving file metadata",
+            },
+        ],
     },
 }


### PR DESCRIPTION
## Summary

- classify desktop file-data references before requiring a `FileDataStore`
- preserve `<invfdo>` payloads as explicitly invalid instead of valid zero-byte data
- expose a non-exhaustive `FileDataStatus` through `Image::data_status()` and `EmbeddedFile::data_status()`
- add page-scoped warnings for invalid or missing embedded payloads
- keep existing `read()` signatures source-compatible

## Problem

`AttachmentInfo::load_data` recognizes `<invfdo>` as an explicitly invalid payload, but `ParseContext::find_file_data` previously tried to access the file-data store first. Sections without a store therefore failed before the marker could be classified.

Returning a default empty blob also made an invalid payload indistinguishable from a legitimate zero-byte file, leaving renderers no reliable way to show degraded content.

## Behavior

The resolver now classifies the reference first:

- `<ifndf>` remains strict and still requires a store plus a matching GUID.
- `<invfdo>` is non-fatal and carries `FileDataStatus::Invalid`.
- absent image or embedded-file data carries `FileDataStatus::Missing`.
- external `<file>` references and unknown reference types retain their existing errors.

For API compatibility, unavailable embedded files still produce an empty reader. Consumers can check `data_status()` and render a broken-content indicator rather than opening the payload.

## Validation

- `cargo test --workspace`
- `cargo fmt --all -- --check`
- `cargo clippy`
- `cargo check -p onenote_parser --no-default-features --lib`
- parsed a representative private desktop-backup section that previously failed
- aggregate corpus check: 25 of 83 physical snapshots exercise `<invfdo>` without a file-data store

The private files contain personal notebook data and are not included. The deterministic resolver paths are covered by unit tests, and the existing corrupted-attachment fixture records the new missing-data status and warnings.

Fixes #35.
Relates to #28.
