### PR TITLE
fix(parser): recover outlines with missing timestamps

### DIFF
--- a/crates/parser/src/one/property_set/outline_element_node.rs
+++ b/crates/parser/src/one/property_set/outline_element_node.rs
@@ -14,7 +14,7 @@ use crate::onestore::Object;
 #[derive(Debug)]
 #[allow(dead_code)]
 pub(crate) struct Data {
-    pub(crate) created_at: Time,
+    pub(crate) created_at: Option<Time>,
     pub(crate) last_modified: Time,
     pub(crate) children: Vec<ExGuid>,
     pub(crate) child_level: u8,
@@ -32,9 +32,7 @@ pub(crate) struct Data {
 pub(crate) fn parse(object: &Object) -> Result<Data> {
     assert_property_set(object, PropertySetId::OutlineElementNode)?;
 
-    let created_at = Time::parse(PropertyType::CreationTimeStamp, object)?.ok_or_else(|| {
-        ErrorKind::MalformedOneNoteFileData("outline element has no creation timestamp".into())
-    })?;
+    let created_at = Time::parse(PropertyType::CreationTimeStamp, object)?;
     let last_modified = Time::parse(PropertyType::LastModifiedTime, object)?.ok_or_else(|| {
         ErrorKind::MalformedOneNoteFileData("outline element has no last modified time".into())
     })?;
@@ -81,4 +79,75 @@ pub(crate) fn parse(object: &Object) -> Result<Data> {
     };
 
     Ok(data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse;
+    use crate::fsshttpb::data::cell_id::CellId;
+    use crate::fsshttpb::data::exguid::ExGuid;
+    use crate::one::property::PropertyType;
+    use crate::one::property_set::PropertySetId;
+    use crate::onestore::shared::compact_id::CompactId;
+    use crate::onestore::shared::object_prop_set::ObjectPropSet;
+    use crate::onestore::shared::prop_set::PropertySet;
+    use crate::onestore::{MappingTable, Object};
+    use crate::reader::Reader;
+    use std::rc::Rc;
+
+    struct TestMapping;
+
+    impl MappingTable for TestMapping {
+        fn resolve_id(&self, _index: usize, _cid: &CompactId) -> Option<ExGuid> {
+            Some(ExGuid::default())
+        }
+
+        fn get_object_space(&self, _index: usize, _cid: &CompactId) -> Option<CellId> {
+            None
+        }
+    }
+
+    #[test]
+    fn accepts_a_missing_creation_timestamp() {
+        let property_ids = [
+            PropertyType::LastModifiedTime,
+            PropertyType::OutlineElementChildLevel,
+            PropertyType::AuthorOriginal,
+            PropertyType::AuthorMostRecent,
+        ];
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(property_ids.len() as u16).to_le_bytes());
+        for property_id in property_ids {
+            bytes.extend_from_slice(&(property_id as u32).to_le_bytes());
+        }
+        bytes.extend_from_slice(&1_u32.to_le_bytes());
+        bytes.push(0);
+
+        let mut reader = Reader::new(&bytes);
+        let object = Object {
+            context_id: Default::default(),
+            jc_id: PropertySetId::OutlineElementNode.as_jcid(),
+            props: ObjectPropSet {
+                object_ids: vec![
+                    CompactId {
+                        n: 0,
+                        guid_index: 0,
+                    },
+                    CompactId {
+                        n: 1,
+                        guid_index: 0,
+                    },
+                ],
+                properties: PropertySet::parse(&mut reader).unwrap(),
+                ..Default::default()
+            },
+            file_data: None,
+            mapping: Rc::new(TestMapping),
+        };
+
+        let data = parse(&object).expect("missing unused timestamp should be non-fatal");
+
+        assert_eq!(data.created_at, None);
+        assert_eq!(data.child_level, 0);
+    }
 }

--- a/crates/parser/src/one/property_set/outline_group.rs
+++ b/crates/parser/src/one/property_set/outline_group.rs
@@ -14,7 +14,7 @@ use crate::onestore::Object;
 #[derive(Debug)]
 #[allow(dead_code)]
 pub(crate) struct Data {
-    pub(crate) last_modified: Time,
+    pub(crate) last_modified: Option<Time>,
     pub(crate) children: Vec<ExGuid>,
     pub(crate) child_level: u8,
 }
@@ -22,9 +22,7 @@ pub(crate) struct Data {
 pub(crate) fn parse(object: &Object) -> Result<Data> {
     assert_property_set(object, PropertySetId::OutlineGroup)?;
 
-    let last_modified = Time::parse(PropertyType::LastModifiedTime, object)?.ok_or_else(|| {
-        ErrorKind::MalformedOneNoteFileData("outline group has no last modified time".into())
-    })?;
+    let last_modified = Time::parse(PropertyType::LastModifiedTime, object)?;
     let children =
         ObjectReference::parse_vec(PropertyType::ElementChildNodes, object)?.unwrap_or_default();
     let child_level = simple::parse_u8(PropertyType::OutlineElementChildLevel, object)?
@@ -39,4 +37,56 @@ pub(crate) fn parse(object: &Object) -> Result<Data> {
     };
 
     Ok(data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse;
+    use crate::fsshttpb::data::cell_id::CellId;
+    use crate::fsshttpb::data::exguid::ExGuid;
+    use crate::one::property::PropertyType;
+    use crate::one::property_set::PropertySetId;
+    use crate::onestore::shared::compact_id::CompactId;
+    use crate::onestore::shared::object_prop_set::ObjectPropSet;
+    use crate::onestore::shared::prop_set::PropertySet;
+    use crate::onestore::{MappingTable, Object};
+    use crate::reader::Reader;
+    use std::rc::Rc;
+
+    struct TestMapping;
+
+    impl MappingTable for TestMapping {
+        fn resolve_id(&self, _index: usize, _cid: &CompactId) -> Option<ExGuid> {
+            None
+        }
+
+        fn get_object_space(&self, _index: usize, _cid: &CompactId) -> Option<CellId> {
+            None
+        }
+    }
+
+    #[test]
+    fn accepts_a_missing_last_modified_time() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&1_u16.to_le_bytes());
+        bytes.extend_from_slice(&(PropertyType::OutlineElementChildLevel as u32).to_le_bytes());
+        bytes.push(0);
+
+        let mut reader = Reader::new(&bytes);
+        let object = Object {
+            context_id: Default::default(),
+            jc_id: PropertySetId::OutlineGroup.as_jcid(),
+            props: ObjectPropSet {
+                properties: PropertySet::parse(&mut reader).unwrap(),
+                ..Default::default()
+            },
+            file_data: None,
+            mapping: Rc::new(TestMapping),
+        };
+
+        let data = parse(&object).expect("missing unused timestamp should be non-fatal");
+
+        assert_eq!(data.last_modified, None);
+        assert_eq!(data.child_level, 0);
+    }
 }

--- a/crates/parser/src/onenote/outline.rs
+++ b/crates/parser/src/onenote/outline.rs
@@ -334,6 +334,12 @@ fn parse_outline_group(
         .get_object(group_id)
         .ok_or_else(|| ErrorKind::MalformedOneNoteData("outline group is missing".into()))?;
     let data = outline_group::parse(group_object)?;
+    if data.last_modified.is_none() {
+        warn!(
+            ctx,
+            "outline group has no last modified time; preserving its contents"
+        );
+    }
 
     let outlines = data
         .children
@@ -358,6 +364,12 @@ pub(crate) fn parse_outline_element(
         .get_object(element_id)
         .ok_or_else(|| ErrorKind::MalformedOneNoteData("outline element is missing".into()))?;
     let data = outline_element_node::parse(element_object)?;
+    if data.created_at.is_none() {
+        warn!(
+            ctx,
+            "outline element has no creation timestamp; preserving its contents"
+        );
+    }
 
     let children = data
         .children


### PR DESCRIPTION
## Summary

- accept a missing `CreationTimeStamp` on `OutlineElementNode`
- accept a missing `LastModifiedTime` on `OutlineGroup`
- preserve each outline tree and add a page-scoped parser warning
- keep fields consumed by the high-level outline model strict

## Rationale

Some OneNote Desktop backup sections omit these timestamps. The parser currently rejects the entire section even though neither value is exposed or consumed by `OutlineElement` or `OutlineGroup`.

This change represents the metadata as optional at the property-set boundary, reports the omission once page context is available, and continues parsing the group's children. It does not invent a timestamp or relax validation of the child level, author references, or element modification time.

## Validation

- focused synthetic tests for both omitted properties
- `cargo test --workspace`
- `cargo fmt --all -- --check`
- `cargo clippy`
- `cargo check -p onenote_parser --no-default-features --lib`
- parsed a representative private desktop-backup section that previously failed and confirmed its page-scoped warning

The private file contains personal notebook data and is not included; the malformed property combinations are covered with minimal synthetic objects.

Fixes #33.
Relates to #11.
