### PR TITLE
fix(parser): accept lossless enum property widths

### DIFF
--- a/crates/parser/src/one/property/page_size.rs
+++ b/crates/parser/src/one/property/page_size.rs
@@ -31,7 +31,7 @@ pub(crate) enum PageSize {
 impl PageSize {
     pub(crate) fn parse(prop_type: PropertyType, object: &Object) -> Result<Option<PageSize>> {
         let value = match object.props.get(prop_type) {
-            Some(value) => value.to_u8().ok_or_else(|| {
+            Some(value) => value.to_u8_lossless().ok_or_else(|| {
                 ErrorKind::MalformedOneNoteFileData("page size is not a u8".into())
             })?,
             None => return Ok(None),

--- a/crates/parser/src/one/property/paragraph_alignment.rs
+++ b/crates/parser/src/one/property/paragraph_alignment.rs
@@ -20,8 +20,8 @@ pub enum ParagraphAlignment {
 impl ParagraphAlignment {
     pub(crate) fn parse(object: &Object) -> Result<Option<ParagraphAlignment>> {
         let value = match object.props.get(PropertyType::ParagraphAlignment) {
-            Some(value) => value.to_u8().ok_or_else(|| {
-                ErrorKind::MalformedOneNoteFileData("page size is not a u8".into())
+            Some(value) => value.to_u8_lossless().ok_or_else(|| {
+                ErrorKind::MalformedOneNoteFileData("paragraph alignment is not a u8".into())
             })?,
             None => return Ok(None),
         };

--- a/crates/parser/src/onestore/shared/property.rs
+++ b/crates/parser/src/onestore/shared/property.rs
@@ -41,6 +41,16 @@ impl PropertyValue {
         }
     }
 
+    pub(crate) fn to_u8_lossless(&self) -> Option<u8> {
+        match self {
+            Self::U8(value) => Some(*value),
+            Self::U16(value) => (*value).try_into().ok(),
+            Self::U32(value) => (*value).try_into().ok(),
+            Self::U64(value) => (*value).try_into().ok(),
+            _ => None,
+        }
+    }
+
     pub(crate) fn to_u16(&self) -> Option<u16> {
         if let Self::U16(v) = self {
             Some(*v)
@@ -271,6 +281,19 @@ mod test {
         )
         .unwrap();
         assert!(matches!(value, PropertyValue::U64(0x0123_4567_89AB_CDEF)));
+    }
+
+    #[test]
+    fn test_property_value_to_u8_lossless() {
+        assert_eq!(PropertyValue::U8(42).to_u8_lossless(), Some(42));
+        assert_eq!(PropertyValue::U16(42).to_u8_lossless(), Some(42));
+        assert_eq!(PropertyValue::U32(42).to_u8_lossless(), Some(42));
+        assert_eq!(PropertyValue::U64(42).to_u8_lossless(), Some(42));
+
+        assert_eq!(PropertyValue::U16(256).to_u8_lossless(), None);
+        assert_eq!(PropertyValue::U32(256).to_u8_lossless(), None);
+        assert_eq!(PropertyValue::U64(256).to_u8_lossless(), None);
+        assert_eq!(PropertyValue::Bool(true).to_u8_lossless(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a checked conversion from unsigned `PropertyValue` variants to `u8`
- accept wider integer encodings for `PageSize` and `ParagraphAlignment`
- reject values above `u8::MAX` without truncation
- correct the paragraph-alignment type error message

## Rationale

OneNote Desktop backup sections can encode these u8-sized enum values with `U16`, `U32`, or `U64` property representations. The semantic value is valid, but the current parser rejects it solely because the storage width is wider than expected.

The conversion is intentionally narrow: it accepts only unsigned integer variants and uses checked conversion. Non-integer values and out-of-range integers remain malformed input.

## Validation

- unit coverage for every accepted unsigned width, overflow, and non-integer rejection
- `cargo test --workspace`
- `cargo fmt --all -- --check`
- `cargo clippy`
- `cargo check -p onenote_parser --no-default-features --lib`
- verified against two private desktop sections that exercise wider enum encodings

The private files contain personal notebook data and are not included; the conversion behavior is fully covered with scalar unit tests.

Fixes #34.
